### PR TITLE
Support non-literal assignments for previous enum entries

### DIFF
--- a/metang.py
+++ b/metang.py
@@ -151,7 +151,18 @@ for line in filter(lambda line: not line.startswith("#"), fin):
 
     split = no_comm.split("=")
     if len(split) > 1:
-        val = int(split[1])
+        valStr = split[1].strip()
+        try:
+            val = int(valStr)
+        except ValueError:
+            found = False
+            for d in enumeration:
+                if valStr == d[0]:
+                    val = d[1]
+                    found = True
+                    break
+            if found == False:
+                raise Exception("Enum entry `" + valStr + "`not found on previous entries")
     idt = split[0].strip()
     if len(idt) > maxlen:
         maxlen = len(idt)


### PR DESCRIPTION
Allows this:
```
ACCESSORY_COLORED_PARASOL
NON_UNIQUE_ACCESSORY_COUNT
ACCESSORY_OLD_UMBRELLA = NON_UNIQUE_ACCESSORY_COUNT
ACCESSORY_SPOTLIGHT
```
To become the following:
```c
    ACCESSORY_COLORED_PARASOL  =  61,
    NON_UNIQUE_ACCESSORY_COUNT =  62,
    ACCESSORY_OLD_UMBRELLA     =  62,
    ACCESSORY_SPOTLIGHT        =  63,
```
    
```c
#define ACCESSORY_COLORED_PARASOL   61
#define NON_UNIQUE_ACCESSORY_COUNT  62
#define ACCESSORY_OLD_UMBRELLA      62
#define ACCESSORY_SPOTLIGHT         63
```

It does not support using enums of values after the one being defined.
