### PR TITLE
add json generator for /generated/*.txt

### DIFF
--- a/metang.py
+++ b/metang.py
@@ -50,12 +50,11 @@ When using the “mask” command, the user must mind the following:
      permitted.
 """
 
+import sys
 from argparse import ArgumentParser
 from pathlib import Path
 
-import sys
-
-from metang.generators import c, py
+from metang.generators import c, json, py
 from metang.lang import Lang
 from metang.mode import Mode
 from metang.options import Options
@@ -162,7 +161,9 @@ for line in filter(lambda line: not line.startswith("#"), fin):
                     found = True
                     break
             if found == False:
-                raise Exception("Enum entry `" + valStr + "`not found on previous entries")
+                raise Exception(
+                    "Enum entry `" + valStr + "`not found on previous entries"
+                )
     idt = split[0].strip()
     if len(idt) > maxlen:
         maxlen = len(idt)
@@ -178,5 +179,6 @@ digits = len(str(val - 1))
 GENERATORS = {
     Lang.c: c.generate,
     Lang.py: py.generate,
+    Lang.json: json.generate,
 }
 GENERATORS[lang](enumeration, opts, maxlen, digits)

--- a/metang/generators/json.py
+++ b/metang/generators/json.py
@@ -1,0 +1,22 @@
+import json
+from metang.mode import Mode
+from metang.options import Options
+
+def generate(enum: list[tuple[str, int]], opts: Options, maxlen: int, digits: int):
+    data = {}
+    prefix = "" if not opts.leader else f"{opts.leader}_"
+
+    if opts.mode & Mode.ENUM:
+        for idt, val in enum:
+            data[f"{prefix}{idt}"] = val
+    else:
+        if len(enum) > 0:
+            data[f"{prefix}{enum[0][0]}"] = 0
+        
+        for idt, val in enum[1:-1]:
+            data[f"{prefix}{idt}"] = 1 << val
+            
+        if len(enum) > 1:
+            data[f"{prefix}{enum[-1][0]}"] = (1 << enum[-1][1]) - 1
+
+    print(json.dumps(data, indent=4), file=opts.fout)

--- a/metang/lang.py
+++ b/metang/lang.py
@@ -4,6 +4,7 @@ from enum import Enum, auto
 class Lang(Enum):
     c = auto()
     py = auto()
+    json = auto()
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
should be the same stuff as the python generator essentially.

wanted this to properly support decomp scripts and have decomp constants inside DSPRE (for instance) without the user having built a decomp project before and without creating a file. 
this can be used to curl and pipe straight into stdout, essentially creating a universal API for pulling constants from pokeplatinum.

if anything is off feel free to adjust